### PR TITLE
Update Backup Models for newer backups

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.5.0-rc02")
+    implementation("androidx.core:core-ktx:1.6.0-alpha02")
     implementation("androidx.appcompat:appcompat:1.3.0-rc01")
     implementation("androidx.compose.ui:ui:${rootProject.extra["compose_version"]}")
     implementation("androidx.compose.ui:ui-tooling:${rootProject.extra["compose_version"]}")
@@ -55,16 +55,16 @@ dependencies {
 
     implementation("tachiyomi.sourceapi:source-api:1.1")
 
-    implementation("com.squareup.okio:okio:2.10.0")
+    implementation("com.squareup.okio:okio:3.0.0")
 
     val accompanistVersion = "0.9.1"
     implementation("com.google.accompanist:accompanist-insets:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
 
-    val kotlinSerializationVersion = "1.2.0"
+    val kotlinSerializationVersion = "1.3.1"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:$kotlinSerializationVersion")
-    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.google.code.gson:gson:2.8.9")
     implementation("com.github.salomonbrys.kotson:kotson:2.5.0")
 
     val roomVersion = "2.3.0"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/Backup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/Backup.kt
@@ -8,5 +8,6 @@ data class Backup(
     @ProtoNumber(1) val backupManga: List<BackupManga>,
     @ProtoNumber(2) var backupCategories: List<BackupCategory> = emptyList(),
     // Bump by 100 to specify this is a 0.x value
-    @ProtoNumber(100) var backupSources: List<BackupSource> = emptyList(),
+    @ProtoNumber(100) var backupBrokenSources: List<BrokenBackupSource> = emptyList(),
+    @ProtoNumber(101) var backupSources: List<BackupSource> = emptyList()
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupHistory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupHistory.kt
@@ -4,7 +4,13 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
 @Serializable
-data class BackupHistory(
+data class BrokenBackupHistory(
     @ProtoNumber(0) var url: String,
     @ProtoNumber(1) var lastRead: Long
+)
+
+@Serializable
+data class BackupHistory(
+    @ProtoNumber(1) var url: String,
+    @ProtoNumber(2) var lastRead: Long
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupManga.kt
@@ -33,8 +33,9 @@ data class BackupManga(
     // Bump by 100 for values that are not saved/implemented in 1.x but are used in 0.x
     @ProtoNumber(100) var favorite: Boolean = true,
     @ProtoNumber(101) var chapterFlags: Int = 0,
-    @ProtoNumber(102) var history: List<BackupHistory> = emptyList(),
-    @ProtoNumber(103) var viewer_flags: Int? = null
+    @ProtoNumber(102) var brokenHistory: List<BrokenBackupHistory> = emptyList(),
+    @ProtoNumber(103) var viewer_flags: Int? = null,
+    @ProtoNumber(104) var history: List<BackupHistory> = emptyList()
 ) {
     fun getMangaImpl(): MangaImpl {
         return MangaImpl().apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/models/BackupSource.kt
@@ -4,7 +4,13 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
 @Serializable
-data class BackupSource(
+data class BrokenBackupSource(
     @ProtoNumber(0) var name: String = "",
     @ProtoNumber(1) var sourceId: Long
+)
+
+@Serializable
+data class BackupSource(
+    @ProtoNumber(1) var name: String = "",
+    @ProtoNumber(2) var sourceId: Long
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.0-alpha15")
+        classpath("com.android.tools.build:gradle:7.0.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 07 21:32:19 ICT 2021
+#Tue Nov 30 23:28:07 IST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
As of merging https://github.com/tachiyomiorg/tachiyomi/pull/5849, Tachiyomi proto.gz Backup Models were updated to conform with non-zero protonumbers. 
This leads to newer backups (by folks who still haven't migrated to MangaDex v5 :sigh:) losing history info after using the Migrator
This PR updates the backup model used in this app (from 7mo ago) to the latest one (as of Stable 0.12.3)

Tested on Tachiyomi Stable 0.12.3 and Preview r3984

Note: Also had to upgrade Gradle, kotlinx.serialization and some other stuff. Can remove if needed

P.S. Should've done this few weeks ago. Totally did not forget about this :p